### PR TITLE
Enhance hero intro animation with improved pill explosion and fade effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ body.post-hero.hov #cd{background:var(--terra);opacity:.65}
 .snav-link.on::before{transform:scaleY(1)}
 .snav-copy{font-family:var(--sans);font-size:9px;font-weight:400;color:rgba(30,26,22,.2);letter-spacing:.04em;margin-top:auto;padding-top:20px;}
 .hero-intro{position:relative}
-.hero-intro__frame{position:sticky;top:0;height:100vh;width:100%;overflow:hidden;background:#263226;display:flex;flex-direction:column;}
+.hero-intro__frame{position:sticky;top:0;height:100vh;width:100%;overflow:hidden;background:#263226;display:flex;flex-direction:column;transition:opacity 0.2s linear;}
 .hero-intro__bar{flex-shrink:0;height:var(--bar-h);display:flex;align-items:center;padding:0 52px;border-bottom:1px solid rgba(236,232,218,.07);justify-content:space-between;z-index:6;}
 .hero-intro__brand{font-family:var(--sans);font-size:11px;font-weight:600;letter-spacing:.22em;text-transform:uppercase;color:rgba(236,232,218,.4);}
 #h-pct{font-family:var(--sans);font-size:10px;font-weight:600;letter-spacing:.18em;color:rgba(236,232,218,.18)}
@@ -540,17 +540,22 @@ function updateHero(){
   positionEndcue();
   const et=eoc(Math.max(0,Math.min(1,(t-0.78)/0.12)));const ec=document.getElementById('endcue');
   ec.style.opacity=et;ec.style.transform='translateY('+((1-et)*16)+'px)';
+  // Pills explode: t=0.90→1.0, ease-out cubic, fly off screen in distinct directions
   const st=Math.max(0,Math.min(1,(t-0.90)/0.10));
   if(st>0){
     const se=eoc(st);
-    [[-0.18,0.14],[-0.14,0.08],[-0.10,-0.12],[-0.04,-0.20],[0,-0.25],[0.04,-0.20],[0.10,-0.12],[0.14,0.08],[0.18,0.14]].forEach(([dx,dy],i)=>{
+    // Each [dx,dy] is a fraction of viewport width/height — large enough to clear the screen
+    [[-1.5,0.8],[-1.2,-0.4],[-0.8,-1.0],[-0.4,-1.4],[0,-1.6],[0.5,-1.3],[1.0,-0.8],[1.3,0.3],[1.4,0.9]].forEach(([dx,dy],i)=>{
       const el=document.getElementById('hp'+i);if(!el)return;
-      el.style.transform='translate(calc(-50% + '+(dx*window.innerWidth*se)+'px),calc(-50% + '+(dy*window.innerHeight*se)+'px)) scale('+(1-se*0.28)+')';
-      el.style.opacity=Math.max(0,1-se*1.3);
+      el.style.transform='translate(calc(-50% + '+(dx*window.innerWidth*se)+'px),calc(-50% + '+(dy*window.innerHeight*se)+'px)) scale('+Math.max(0,1-se)+')';
+      el.style.opacity=Math.max(0,1-se);
     });
-    ec.style.opacity=Math.max(0,et-se*3);ht.style.opacity=Math.max(0,tp-se*2.2);hs.style.opacity=Math.max(0,sp-se*2.2);
+    ec.style.opacity=Math.max(0,et-se*3);
+    ht.style.opacity=Math.max(0,1-se);
+    hs.style.opacity=Math.max(0,1-se);
   }
-  document.querySelector('.hero-intro__frame').style.opacity=t>0.95?Math.max(0,1-(t-0.95)/0.05):1;
+  // Frame fade: starts at t=0.75, fully gone at t=1.0
+  document.querySelector('.hero-intro__frame').style.opacity=t<0.75?1:Math.max(0,1-(t-0.75)/0.25);
 }
 
 const SVCS=[


### PR DESCRIPTION
## Summary
This PR refines the hero intro section's exit animation sequence, making the pill explosion effect more dramatic and adjusting the frame fade timing for a smoother visual transition.

## Key Changes
- **Pill explosion trajectories**: Updated displacement vectors to be significantly larger (e.g., from `[-0.18, 0.14]` to `[-1.5, 0.8]`), causing pills to fly much further off-screen in distinct directions
- **Pill scaling and opacity**: Changed from gradual scale reduction (`1-se*0.28`) to complete scale-out (`1-se`), and simplified opacity fade to match (`1-se`)
- **Frame fade timing**: Shifted fade start from `t=0.95` to `t=0.75` with extended duration (0.25s instead of 0.05s), creating a longer, more gradual fade effect
- **Text element opacity**: Simplified header and subtitle opacity calculations to use consistent `1-se` fade instead of different multipliers
- **CSS enhancement**: Added `transition:opacity 0.2s linear;` to `.hero-intro__frame` for smoother opacity transitions
- **Code clarity**: Added explanatory comments for animation phases and parameter meanings

## Implementation Details
- The pill explosion now uses viewport-relative displacement values that are substantially larger, ensuring elements clear the screen completely
- The frame fade now begins earlier in the animation sequence (at 75% completion) and takes longer to complete, providing a more graceful exit
- All opacity calculations now use consistent easing patterns for a more cohesive animation feel

https://claude.ai/code/session_01VTrzd4v5erv6M6ZhxwxVsg